### PR TITLE
FS-17: Fixes for Deletes and Getting Reasons

### DIFF
--- a/src/main/java/com/fleet/status/dao/impl/EventDAO.java
+++ b/src/main/java/com/fleet/status/dao/impl/EventDAO.java
@@ -197,7 +197,7 @@ public class EventDAO implements IEventDAO {
             event.setDowntime(validateEventFields(currentRow.get(12)));
 
             // Set reasons
-            event.setReasonString(getReasons(event.getAircraft().getAircraftId()));
+            event.setReasonString(getReasons(event.getEventId()));
 
             // Add event to list
             events.add(event);

--- a/src/main/java/com/fleet/status/dao/impl/EventDAO.java
+++ b/src/main/java/com/fleet/status/dao/impl/EventDAO.java
@@ -123,11 +123,11 @@ public class EventDAO implements IEventDAO {
         }
     }
 
-    private List<Object[]> getReasonsForAircraft(Long aircraftId) {
+    private List<Object[]> getReasonsForEvent(Long eventId) {
         try {
             // Call a stored procedure to get the reason information
-            Query query = entityManager.createNativeQuery("EXEC uspGetReasonsForAircraft :aircraftId");
-            query.setParameter("aircraftId", aircraftId);
+            Query query = entityManager.createNativeQuery("EXEC uspGetReasonsForEvent :eventId");
+            query.setParameter("eventId", eventId);
 
             return query.getResultList();
         } catch (Exception e) {
@@ -212,11 +212,11 @@ public class EventDAO implements IEventDAO {
 
     /**
      * Formats reasons into a string
-     * @param aircraftId aircraft
+     * @param eventId eventId
      * @return comma separated reasons
      */
-    private String getReasons(Long aircraftId) {
-        List<Object[]> reasons = getReasonsForAircraft(aircraftId);
+    private String getReasons(Long eventId) {
+        List<Object[]> reasons = getReasonsForEvent(eventId);
 
         // Object[0] stand for intReasonId
         // Object[1] stand for strReason

--- a/src/main/resources/database/DB_Reset_Script.sql
+++ b/src/main/resources/database/DB_Reset_Script.sql
@@ -39,7 +39,7 @@ IF OBJECT_ID('uspShowCarrierAircraftOOS')		        IS NOT NULL DROP PROCEDURE us
 IF OBJECT_ID('uspShowCarrierAircraftIS')		        IS NOT NULL DROP PROCEDURE uspShowCarrierAircraftIS;
 IF OBJECT_ID('uspUpdateAircraftServiceStatus')	        IS NOT NULL DROP PROCEDURE uspUpdateAircraftServiceStatus;
 IF OBJECT_ID('uspDeleteAircraft')				        IS NOT NULL DROP PROCEDURE uspDeleteAircraft;
-IF OBJECT_ID('uspGetReasonsForAircraft')				IS NOT NULL DROP PROCEDURE uspGetReasonsForAircraft;
+IF OBJECT_ID('uspGetReasonsForEvent')					IS NOT NULL DROP PROCEDURE uspGetReasonsForEvent;
 
 -- -------------------------------------------------------------------------
 -- Create Tables
@@ -499,8 +499,8 @@ GO
 -- -------------------------------------------------------------------------
 GO
 
-CREATE PROCEDURE uspGetReasonsForAircraft
-    @intAircraftId		AS INTEGER
+CREATE PROCEDURE uspGetReasonsForEvent
+    @intEventId		AS INTEGER
 AS
 
 BEGIN
@@ -509,14 +509,12 @@ SELECT
 	TR.intReasonId,
 	TR.strReason 
 FROM 
-	TEvents as TE JOIN TAircraft as TA
-		ON TA.intAircraftId = TE.intAircraftId
-	JOIN TEventReasons as TER
+	TEvents as TE JOIN TEventReasons as TER
 		ON TER.intEventId = TE.intEventId
 	JOIN TReasons as TR
 		ON TR.intReasonId = TER.intReasonId
 WHERE 
-	TE.intAircraftId = @intAircraftId;
+	TE.intEventId = @intEventId;
 
 END;
 

--- a/src/main/resources/database/DB_Reset_Script.sql
+++ b/src/main/resources/database/DB_Reset_Script.sql
@@ -486,7 +486,7 @@ AS
 
 BEGIN
 
-DELETE FROM TEventReasons WHERE intEventId = (SELECT intEventId FROM TEvents WHERE intAircraftId = @intAircraftId);
+DELETE FROM TEventReasons WHERE intEventId IN (SELECT intEventId FROM TEvents WHERE intAircraftId = @intAircraftId);
 DELETE FROM TEvents WHERE intAircraftId = @intAircraftId;
 DELETE FROM TAircraft WHERE intAircraftId = @intAircraftId;
 


### PR DESCRIPTION
#  Fixes for Deletes and Getting Reasons

## Description
Jira Story: [FS-17](https://fleetstatus.atlassian.net/browse/FS-17)

Changes:
- Fixed delete errors when multiple rows in TEvents have the same aircraftId
- Updated getReasonsForAircraft (or Event now) to use the event ID instead of aircraft

## Testing Details
N/A

## Configuration Updates
Updated DB script. Make sure to drop everything in your DB first, then run the new script.

[FS-17]: https://fleetstatus.atlassian.net/browse/FS-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ