### PR TITLE
add History page and filter function

### DIFF
--- a/src/main/java/com/fleet/status/controller/FleetStatusController.java
+++ b/src/main/java/com/fleet/status/controller/FleetStatusController.java
@@ -44,6 +44,11 @@ public class FleetStatusController {
         return "AircraftStatus";
     }
 
+    @GetMapping("/History")
+    public String History() {
+        return "History";
+    }
+
     @GetMapping("/getAllAircraft")
     @ResponseBody
     public ResponseEntity<List<Event>> getHomepageAircraft() {
@@ -63,6 +68,22 @@ public class FleetStatusController {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
+
+    @GetMapping("/getHistory")
+    @ResponseBody
+    public ResponseEntity<List<Event>> getHistory(
+            @RequestParam(required = false) Integer carrierId,
+            @RequestParam(required = false) Integer typeId,
+            @RequestParam(required = false) String tailNumber,
+            @RequestParam(required = false) List<Integer> reasonIds) {
+        try {
+            List<Event> events = eventService.getFilteredEvents(carrierId, typeId, tailNumber, reasonIds);
+            return new ResponseEntity<>(events, HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
 
     @PostMapping(value="/saveEvent", consumes = "application/json", produces = "application/json")
     @ResponseBody

--- a/src/main/java/com/fleet/status/dao/IEventDAO.java
+++ b/src/main/java/com/fleet/status/dao/IEventDAO.java
@@ -23,4 +23,6 @@ public interface IEventDAO {
     List<Event> getAllAircraftFromCarrierIS(int carrierId);
 
     void updateAircraft(Event event);
+
+    List<Event> getFilteredEvents(Integer carrierId, Integer typeId, String tailNumber, List<Integer> reasonIds);
 }

--- a/src/main/java/com/fleet/status/service/IEventService.java
+++ b/src/main/java/com/fleet/status/service/IEventService.java
@@ -26,4 +26,6 @@ public interface IEventService {
     long calculateDownTime(String startTime, String endTime);
 
     void showBackInService(int aircraftId);
+
+    List<Event> getFilteredEvents(Integer carrierId, Integer typeId, String tailNumber, List<Integer> reasonIds);
 }

--- a/src/main/java/com/fleet/status/service/impl/EventService.java
+++ b/src/main/java/com/fleet/status/service/impl/EventService.java
@@ -95,4 +95,9 @@ public class EventService implements IEventService {
         event.setBackInService(1);
         eventDAO.updateAircraft(event);
     }
+
+    @Override
+    public List<Event> getFilteredEvents(Integer carrierId, Integer typeId, String tailNumber, List<Integer> reasonIds) {
+        return eventDAO.getFilteredEvents(carrierId, typeId, tailNumber, reasonIds);
+    }
 }

--- a/src/main/resources/database/DB_Reset_Script.sql
+++ b/src/main/resources/database/DB_Reset_Script.sql
@@ -25,11 +25,12 @@ IF OBJECT_ID('TRoles')	            	IS NOT NULL DROP TABLE TRoles;
 -- -------------------------------------------------------------------------
 -- Drop Views
 -- -------------------------------------------------------------------------
-IF OBJECT_ID('vAllAircraft')			IS NOT NULL DROP VIEW vAllAircraft;
-IF OBJECT_ID('vOutOfServiceAircraft')	IS NOT NULL DROP VIEW vOutOfServiceAircraft;
-IF OBJECT_ID('vInServiceAircraft')		IS NOT NULL DROP VIEW vInServiceAircraft;
-IF OBJECT_ID('vAllReason')		    	IS NOT NULL DROP VIEW vAllReason;
-IF OBJECT_ID('vAllCarrier')		    	IS NOT NULL DROP VIEW vAllCarrier;
+IF OBJECT_ID('vAllAircraft')			    IS NOT NULL DROP VIEW vAllAircraft;
+IF OBJECT_ID('vOutOfServiceAircraft')	    IS NOT NULL DROP VIEW vOutOfServiceAircraft;
+IF OBJECT_ID('vInServiceAircraft')		    IS NOT NULL DROP VIEW vInServiceAircraft;
+IF OBJECT_ID('vAllReason')		    	    IS NOT NULL DROP VIEW vAllReason;
+IF OBJECT_ID('vAllCarrier')		        	IS NOT NULL DROP VIEW vAllCarrier;
+IF OBJECT_ID('vEventHistory')		    	IS NOT NULL DROP VIEW vEventHistory;
 
 -- -------------------------------------------------------------------------
 -- Drop Stored Procedures
@@ -308,6 +309,38 @@ GO
 CREATE VIEW vAllCarrier
 AS
 SELECT * FROM TCarriers
+
+GO
+
+-- -------------------------------------------------------------------------
+-- View to show all events as history
+-- -------------------------------------------------------------------------
+GO
+
+CREATE VIEW vEventHistory AS
+SELECT
+    TC.intCarrierId,
+    TC.strCarrier,
+    TT.intTypeId,
+    TT.strType,
+    TA.intAircraftId,
+    TA.strTailNumber,
+    TE.intEventid,
+    TE.strRemark,
+    TE.dtmNextUpdate,
+    TE.blnBackInService,
+    TE.dtmStartTime,
+    TE.dtmEndTime,
+    TE.strDownTime
+FROM
+    TEvents AS TE
+        JOIN
+    TAircraft AS TA ON TE.intAircraftId = TA.intAircraftId
+        JOIN TCarriers as TC
+             ON TC.intCarrierId = TA.intCarrierId
+        JOIN TTypes as TT
+             ON TT.intTypeId = TA.intTypeId
+
 
 GO
 

--- a/src/main/resources/static/js/AircraftStatus/HistoryTable.js
+++ b/src/main/resources/static/js/AircraftStatus/HistoryTable.js
@@ -1,0 +1,138 @@
+window.onload = function() {
+    loadCarriers();
+    loadTypes();
+    loadReasons();
+    loadAircrafts();
+};
+
+// Loading carrier list
+function loadCarriers() {
+    fetch("/getAllCarrier")
+        .then(response => response.json())
+        .then(data => {
+            const carrierSelect = document.getElementById("carrierSelect");
+            data.forEach(carrier => {
+                const option = document.createElement("option");
+                option.value = carrier.carrierId;
+                option.text = carrier.carrierName;
+                carrierSelect.appendChild(option);
+            });
+        })
+        .catch(error => console.error("Error loading carriers:", error));
+}
+
+// Load Type List
+function loadTypes() {
+    fetch("/getAllTypes")
+        .then(response => response.json())
+        .then(data => {
+            const typeSelect = document.getElementById("typeSelect");
+            data.forEach(type => {
+                const option = document.createElement("option");
+                option.value = type.typeId;
+                option.text = type.typeName;
+                typeSelect.appendChild(option);
+            });
+        })
+        .catch(error => console.error("Error loading types:", error));
+}
+
+// Loading Reason List
+function loadReasons() {
+    fetch("/getAllReason")
+        .then(response => response.json())
+        .then(data => {
+            const reasonSelect = document.getElementById("reasonIds");
+            data.forEach(reason => {
+                const option = document.createElement("option");
+                option.value = reason.reasonId;
+                option.text = reason.reason;
+                reasonSelect.appendChild(option);
+            });
+        })
+        .catch(error => console.error("Error loading reasons:", error));
+}
+
+// Load aircraft list (tail numbers)
+function loadAircrafts() {
+    fetch("/findAllAircraft")
+        .then(response => response.json())
+        .then(data => {
+            const tailSelect = document.getElementById("tailSelect");
+            data.forEach(aircraft => {
+                const option = document.createElement("option");
+                option.value = aircraft.tailNumber; //Preparing for fuzzy search
+                option.text = aircraft.tailNumber;
+                tailSelect.appendChild(option);
+            });
+        })
+        .catch(error => console.error("Error loading aircrafts:", error));
+}
+
+function getEventHistory() {
+    const carrierId = document.getElementById("carrierSelect").value;
+    const typeId = document.getElementById("typeSelect").value;
+    const tailNumber = document.getElementById("tailSelect").value;
+
+    // Get the selected reason ID in the multi-select drop-down box
+    const reasonSelect = document.getElementById("reasonIds");
+    const selectedReasons = Array.from(reasonSelect.options)
+        .filter(option => option.selected)
+        .map(option => option.value);
+
+    // Constructs a URL and adds selected query parameters to the URL
+    const url = new URL("/getHistory", window.location.origin);
+
+    if (carrierId) url.searchParams.append("carrierId", carrierId);
+    if (typeId) url.searchParams.append("typeId", typeId);
+    if (tailNumber) url.searchParams.append("tailNumber", tailNumber);
+    selectedReasons.forEach(reasonId => {
+        url.searchParams.append("reasonIds", reasonId);
+    });
+
+    // Send a request to get data
+    fetch(url)
+        .then(response => response.json())
+        .then(data => {
+            const tableBody = document.getElementById("statusDisplay");
+            tableBody.innerHTML = '';  // Clear previous data
+
+            if (data.length === 0) {
+                tableBody.innerHTML = `
+                <tr class="text-white text-center bg-dark">
+                    <td colspan="5">No current event history.</td>
+                </tr>`;
+                return;
+            }
+
+            displayEventHistory(data);
+        })
+        .catch(error => console.log("Error fetching event history:", error));
+}
+
+function displayEventHistory(events) {
+    const tableBody = document.getElementById("statusDisplay");
+
+    events.forEach(event => {
+        const row = document.createElement('tr');
+        row.classList.add("text-white", "bg-dark");
+        row.innerHTML = `
+            <td>${new Date(event.startTime).toLocaleDateString()}</td>
+            <td>${event.aircraft.tailNumber}</td>
+            <td>${event.reasonString}</td>
+            <td>${event.remark}</td>
+            <td>${event.nextUpdate}</td>
+        `;
+        tableBody.appendChild(row);
+    });
+}
+
+function generateReport() {
+    // Placeholder for generating report functionality
+    alert("Generating aircraft down time report...");
+}
+
+function exportData() {
+    // Placeholder for export functionality
+    alert("Exporting data...");
+}

--- a/src/main/resources/templates/History.html
+++ b/src/main/resources/templates/History.html
@@ -4,7 +4,7 @@
   <meta charset="ISO-8859-1"/>
   <title>Fleet Overview</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
-  <link rel="stylesheet" href="/css/style.css"></link>
+  <link rel="stylesheet" href="/css/style.css">
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.min.js" integrity="sha384-cuYeSxntonz0PPNlHhBs68uyIAVpIIOZZ5JqeqvYYIcEL727kskC66kF92t6Xl2V" crossorigin="anonymous"></script>
 </head>
 <body class="p-3 mb-2 bg-dark text-white">
@@ -16,45 +16,63 @@
 </div>
 <br>
 
-<div class="row" id="addAircraftForm">
-  <div class="col-sm">
-    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addTailEvent">Aircraft Down Time Report</button>
-    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addTailEvent">Export</button>
+<!-- Filter form -->
+<div class="container mb-4">
+  <div class="row">
+    <div class="col-sm-3">
+      <label for="carrierSelect" class="form-label">Carrier:</label>
+      <select id="carrierSelect" class="form-select">
+        <option value="">Select Carrier</option>
+      </select>
+    </div>
+    <div class="col-sm-3">
+      <label for="typeSelect" class="form-label">Type:</label>
+      <select id="typeSelect" class="form-select">
+        <option value="">Select Type</option>
+      </select>
+    </div>
+    <div class="col-sm-3">
+      <label for="tailSelect" class="form-label">Tail Number:</label>
+      <select id="tailSelect" class="form-select">
+        <option value="">Select Tail Number</option>
+      </select>
+    </div>
+    <div class="col-sm-3">
+      <label for="reasonIds" class="form-label">Reason:</label>
+      <select id="reasonIds" class="form-select" multiple>
+        <!-- Dynamically loading reason options -->
+      </select>
+    </div>
+  </div>
+  <div class="row mt-3">
+    <div class="col-sm-3">
+      <button class="btn btn-primary" onclick="getEventHistory()">Filter</button>
+    </div>
+  </div>
 </div>
 
+<!-- Export and Report Buttons -->
+<div class="row" id="addAircraftForm">
+  <div class="col-sm">
+    <button type="button" class="btn btn-primary" onclick="generateReport()">Aircraft Down Time Report</button>
+    <button type="button" class="btn btn-primary" onclick="exportData()">Export</button>
+  </div>
+</div>
+
+<!-- Event History Table -->
 <div class="container">
-  <table class="table table-striped">
+  <table class="table text-white">
     <thead>
     <tr>
       <th scope="col">Event Date</th>
       <th scope="col">Tail #</th>
       <th scope="col">Reason</th>
       <th scope="col">Remark</th>
-      <th scope="col">Down Time</th>
+      <th scope="col">Next Update</th>
     </tr>
     </thead>
-    <tbody>
-    <tr>
-      <th scope="row">26 Oct 2024</th>
-      <td>N775SA</td>
-      <td>AOG</td>
-      <td>Thurst reverser half replacement</td>
-      <td>2d 12h 15m</td>
-    </tr>
-    <tr>
-      <th scope="row">28 Oct 2024</th>
-      <td>N777SA</td>
-      <td>Damage</td>
-      <td>GPU Door</td>
-      <td>12h 15m</td>
-    </tr>
-    <tr>
-      <th scope="row">29 Oct 2024</th>
-      <td>N775SA</td>
-      <td>AOG</td>
-      <td>Thurst reverser half replacement</td>
-      <td>2d 12h 15m</td>
-    </tr>
+    <tbody id="statusDisplay">
+    <!-- Dynamic event data will be inserted here -->
     </tbody>
   </table>
 </div>
@@ -63,6 +81,6 @@
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script src="/js/navbar/SideMenu.js"></script>
-
+<script src="/js/AircraftStatus/HistoryTable.js" rel="script"></script>
 </body>
 </html>


### PR DESCRIPTION
# Title of Pull Request

## Description
[Jira Link](https://fleetstatus.atlassian.net/browse/FS-24)

- Added a History page for tracking incident history with advanced filtering capabilities. This page allows users to dynamically filter incidents based on various criteria such as carrier, type, tail number, and reason.
- Implemented advanced filtering logic in `getFilteredEvents` to support filtering events based on multiple selected reasons, while ensuring only events that contain all specified reasons are included.

## Testing Details
Manual testing passed:
Verified that each drop-down list was populated with data from the backend and displayed correctly.
Tested each filter individually and in combination to ensure accurate filtering of results.
Tested multi-select reason filtering to ensure only events with all selected reasons were displayed.
Verified that the page gracefully handled errors, such as network issues or invalid filter input.

## Configuration Updates
Updated DB script. Make sure to drop everything in your DB first, then run the new script.